### PR TITLE
fix(router): authenticateRoutes 네이밍 오타 및 export 방식 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,12 @@
 import "./App.css";
 import { Route, Routes } from "react-router-dom";
 import routes from "./router/router";
-const { publicRoutes, AuthenticateRoutes } = routes;
+const { publicRoutes, authenticateRoutes } = routes;
 import type { RouteConfig } from "./router/router";
 
 function App() {
-  const allRoutes: RouteConfig[] = [...publicRoutes, ...authenticatedRoutes];
-  
+  const allRoutes: RouteConfig[] = [...publicRoutes, ...authenticateRoutes];
+
   return (
     <Routes>
       {allRoutes.map((route) => {

--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -14,4 +14,4 @@ const publicRoutes: RouteConfig[] = [
 
 const authenticateRoutes: RouteConfig[] = [];
 
-export { publicRoutes, authenticateRoutes };
+export default { publicRoutes, authenticateRoutes };


### PR DESCRIPTION
## 📝 작업 내용
- router 모듈의 export 방식을 export default로 변경하여 import routes from "./router/router" 구문에서 발생하던 import 불일치 문제 해결
- router 모듈에서 카멜케이스로 변경한 authenticateRoutes가 구조분해 할당 시 기존 표기(AuthenticateRoutes)로 남아있던 문제 해결
- authenticateRoutes 관련 오타로 인한 참조 오류 해결


