### PR TITLE
feat: 메인페이지 api 연결

### DIFF
--- a/src/Pages/Login/Login.tsx
+++ b/src/Pages/Login/Login.tsx
@@ -49,9 +49,9 @@ const Login = () => {
         setUserInfo(info);
 
         const authHeader = res.headers["authorization"];
-        const token = authHeader.startsWith("Bearer ")
+        const token = authHeader?.startsWith("Bearer ")
           ? authHeader.slice(7)
-          : authHeader;
+          : authHeader ?? "";
 
         if (token) {
           localStorage.setItem("accessToken", token);

--- a/src/Pages/Main/Main.tsx
+++ b/src/Pages/Main/Main.tsx
@@ -27,7 +27,7 @@ const Main = () => {
 
   useEffect(() => {
     const img = localStorage.getItem("profileImg");
-    setProfileUrl(img as string);
+    setProfileUrl(img ?? "");
 
     const getTodayWeather = async () => {
       try {

--- a/src/Pages/Main/Main.tsx
+++ b/src/Pages/Main/Main.tsx
@@ -1,34 +1,72 @@
 import style from "./Main.module.css";
 import Coin from "../../assets/Coin.svg";
-import ProfileImg from "../../assets/ProfileImg.svg";
 import Weather from "../../components/Main/Weather/Weather";
 import NavItem from "../../components/Main/NavItem/NavItem";
 import MyPageThumbnail from "../../assets/MyPageThumbnail.svg";
 import MissionStartThumbnail from "../../assets/MissionStartThumbnail.svg";
+import { useEffect, useState } from "react";
+import { getPoint, getWeather } from "../../api/main";
+import type { HourlyWeather, WeatherInfo } from "../../types/weather";
 
 const Main = () => {
   const mypageItems = ["활동내역", "내 지갑", "리워드 샵"];
+  const [point, setPoint] = useState(0);
+  const [profileUrl, setProfileUrl] = useState("");
+  const [weatherInfo, setWeatherInfo] = useState<WeatherInfo>({
+    temp: 0,
+    icon: "",
+    todayMax: 0,
+    todayMin: 0,
+  });
+  const [hourlyWeather, setHourlyWeather] = useState<HourlyWeather[]>([]);
 
   const date = new Date();
   const year = date.getFullYear();
   const month = date.getMonth() + 1;
   const day = date.getDate();
 
+  useEffect(() => {
+    const img = localStorage.getItem("profileImg");
+    setProfileUrl(img as string);
+
+    const getTodayWeather = async () => {
+      try {
+        const res = await getWeather();
+        setWeatherInfo(res.data.data.current);
+        setHourlyWeather(res.data.data.hourly6);
+      } catch (e) {
+        console.log(e);
+      }
+    };
+
+    const getUserPoint = async () => {
+      try {
+        const point = await getPoint();
+        setPoint(point.data.data.point);
+      } catch (e) {
+        console.log(e);
+      }
+    };
+
+    getTodayWeather();
+    getUserPoint();
+  }, []);
+
   return (
     <div className={style.wrapper}>
       <div className={style.header}>
         <div className={style.coin}>
           <img src={Coin} />
-          <p>1000</p>
+          <p>{point}</p>
         </div>
         <div className={style.profileImg}>
-          <img src={ProfileImg} />
+          <img src={profileUrl} alt="프로필" />
         </div>
       </div>
       <p className={style.date}>
         {year}년 {month}월 {day}일
       </p>
-      <Weather />
+      <Weather weatherInfo={weatherInfo} hourlyWeather={hourlyWeather} />
       <div className={style.navBar}>
         <NavItem
           thumbnail={MyPageThumbnail}

--- a/src/Pages/Main/Main.tsx
+++ b/src/Pages/Main/Main.tsx
@@ -9,6 +9,11 @@ import MissionStartThumbnail from "../../assets/MissionStartThumbnail.svg";
 const Main = () => {
   const mypageItems = ["활동내역", "내 지갑", "리워드 샵"];
 
+  const date = new Date();
+  const year = date.getFullYear();
+  const month = date.getMonth() + 1;
+  const day = date.getDate();
+
   return (
     <div className={style.wrapper}>
       <div className={style.header}>
@@ -20,7 +25,9 @@ const Main = () => {
           <img src={ProfileImg} />
         </div>
       </div>
-      <p className={style.date}>2025년 08월 26일</p>
+      <p className={style.date}>
+        {year}년 {month}월 {day}일
+      </p>
       <Weather />
       <div className={style.navBar}>
         <NavItem

--- a/src/api/Auth.ts
+++ b/src/api/Auth.ts
@@ -1,6 +1,6 @@
 // src/api/auth.ts
 import axiosInstance from "../lib/axiosInstance";
-import type { UserInfo } from "../types/userInfo";
+import type { LoginInput } from "../types/userInfo";
 
 export interface SignupReq {
   email: string;
@@ -23,6 +23,6 @@ export const signup = async (payload: SignupReq): Promise<SignupRes> => {
   return data;
 };
 
-export const requestLogin = async (userInfo: UserInfo) => {
+export const requestLogin = async (userInfo: LoginInput) => {
   return await axiosInstance.post("/api/v1/auth/login", userInfo);
 };

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,6 +1,6 @@
 // src/api/auth.ts
 import axiosInstance from "../lib/axiosInstance";
-import type { UserInfo } from "../types/userInfo";
+import type { LoginInput } from "../types/userInfo";
 
 export interface SignupReq {
   email: string;
@@ -23,6 +23,6 @@ export const signup = async (payload: SignupReq): Promise<SignupRes> => {
   return data;
 };
 
-export const requestLogin = async (userInfo: UserInfo) => {
+export const requestLogin = async (userInfo: LoginInput) => {
   return await axiosInstance.post("/api/v1/auth/login", userInfo);
 };

--- a/src/api/main.ts
+++ b/src/api/main.ts
@@ -1,0 +1,9 @@
+import axiosInstance from "../lib/axiosInstance";
+
+export const getWeather = async () => {
+  return await axiosInstance.get("/api/v1/weather");
+};
+
+export const getPoint = async () => {
+  return await axiosInstance.get("/api/v1/wallet/my-point");
+};

--- a/src/components/Main/NavItem/NavItem.module.css
+++ b/src/components/Main/NavItem/NavItem.module.css
@@ -17,22 +17,27 @@
   background-color: aqua;
 }
 
-.title {
+.navButton {
+  all: unset;
   display: flex;
+  align-items: flex-end;
+  justify-content: center;
   gap: 8px;
+  margin: 16px 0;
+  cursor: pointer;
 }
 
-.title > p {
+.navButton > p {
   font-size: 16px;
   font-weight: bolder;
 }
 
-.navButton {
-  all: unset;
+.navButton > img {
+  width: 18px;
+  height: 12px;
 }
 
 .contents {
-  margin-top: 6px;
   display: flex;
   flex-wrap: wrap;
   gap: 6px;

--- a/src/components/Main/NavItem/NavItem.module.css
+++ b/src/components/Main/NavItem/NavItem.module.css
@@ -35,6 +35,7 @@
 .navButton > img {
   width: 18px;
   height: 12px;
+  flex: 0 0 auto;
 }
 
 .contents {

--- a/src/components/Main/NavItem/NavItem.tsx
+++ b/src/components/Main/NavItem/NavItem.tsx
@@ -29,12 +29,10 @@ const NavItem = ({ thumbnail, title, contents }: Props) => {
       <div className={style.img}>
         <img src={thumbnail} />
       </div>
-      <div className={style.title}>
+      <button className={style.navButton} onClick={routePage}>
         <p>{title}</p>
-        <button className={style.navButton} onClick={routePage}>
-          <img src={Arrow} />
-        </button>
-      </div>
+        <img src={Arrow} />
+      </button>
       <div className={style.contents}>{contents}</div>
     </div>
   );

--- a/src/components/Main/NavItem/NavItem.tsx
+++ b/src/components/Main/NavItem/NavItem.tsx
@@ -27,9 +27,9 @@ const NavItem = ({ thumbnail, title, contents }: Props) => {
   return (
     <div className={style.container}>
       <div className={style.img}>
-        <img src={thumbnail} />
+        <img src={thumbnail} alt="썸네일" />
       </div>
-      <button className={style.navButton} onClick={routePage}>
+      <button type="button" className={style.navButton} onClick={routePage}>
         <p>{title}</p>
         <img src={Arrow} />
       </button>

--- a/src/components/Main/Weather/HourlyWeatherCard/HourlyWeatherCard.module.css
+++ b/src/components/Main/Weather/HourlyWeatherCard/HourlyWeatherCard.module.css
@@ -3,17 +3,16 @@
   align-items: center;
   justify-content: center;
   flex-direction: column;
-  gap: 14px;
+  gap: 4px;
 }
 
 .container > p {
-  font-size: 10px;
+  font-size: 10px !important;
   color: white;
-  margin: 0;
+  margin: 0 !important;
 }
 
-.weather {
-  width: 18px;
-  height: 18px;
-  background-color: aqua;
+.weather > img {
+  width: 32px;
+  height: 32px;
 }

--- a/src/components/Main/Weather/HourlyWeatherCard/HourlyWeatherCard.tsx
+++ b/src/components/Main/Weather/HourlyWeatherCard/HourlyWeatherCard.tsx
@@ -1,11 +1,20 @@
+import type { HourlyWeather } from "../../../../types/weather";
 import style from "./HourlyWeatherCard.module.css";
 
-const HourlyWeatherCard = () => {
+type Props = {
+  hourlyWeather: HourlyWeather;
+};
+
+const HourlyWeatherCard = ({ hourlyWeather }: Props) => {
   return (
     <div className={style.container}>
-      <p>오후 1시</p>
-      <div className={style.weather}></div>
-      <p>22도</p>
+      <p>{hourlyWeather?.time}</p>
+      <div className={style.weather}>
+        <img
+          src={`https://openweathermap.org/img/wn/${hourlyWeather?.icon}@2x.png`}
+        />
+      </div>
+      <p>{Math.round(hourlyWeather?.temp)}°</p>
     </div>
   );
 };

--- a/src/components/Main/Weather/Weather.module.css
+++ b/src/components/Main/Weather/Weather.module.css
@@ -16,14 +16,11 @@
 .container span {
   font-size: 48px;
   color: white;
-  margin-bottom: 16px;
 }
 
-.weatherIcon {
-  width: 30px;
-  height: 30px;
-  background-color: aqua;
-  margin-bottom: 16px;
+.weatherIcon > img {
+  width: 60px;
+  height: 60px;
 }
 
 .temperature {

--- a/src/components/Main/Weather/Weather.tsx
+++ b/src/components/Main/Weather/Weather.tsx
@@ -1,24 +1,36 @@
+import type { HourlyWeather, WeatherInfo } from "../../../types/weather";
 import HourlyWeatherCard from "./HourlyWeatherCard/HourlyWeatherCard";
 import style from "./Weather.module.css";
 
-const Weather = () => {
+type Props = {
+  weatherInfo: WeatherInfo | null;
+  hourlyWeather: HourlyWeather[];
+};
+
+const Weather = ({ weatherInfo, hourlyWeather }: Props) => {
+  if (!weatherInfo || !hourlyWeather) {
+    return <div>날씨 정보를 불러오고 있습니다.</div>;
+  }
+
   return (
     <div className={style.container}>
       <p>구미시</p>
-      <span>25도</span>
-      <div className={style.weatherIcon}>구름</div>
+      <span>{Math.round(weatherInfo?.temp)}°</span>
+      <div className={style.weatherIcon}>
+        <img
+          src={`https://openweathermap.org/img/wn/${weatherInfo?.icon}@2x.png`}
+          alt="날씨"
+        />
+      </div>
       <div className={style.temperature}>
-        <p>최고 32도</p>
-        <p>최저 19도</p>
+        <p>최고 {Math.round(weatherInfo?.todayMax)}°</p>
+        <p>최저 {Math.round(weatherInfo?.todayMin)}°</p>
       </div>
       <hr />
       <div className={style.hourlyWeather}>
-        <HourlyWeatherCard />
-        <HourlyWeatherCard />
-        <HourlyWeatherCard />
-        <HourlyWeatherCard />
-        <HourlyWeatherCard />
-        <HourlyWeatherCard />
+        {hourlyWeather?.map((item, idx) => (
+          <HourlyWeatherCard key={idx} hourlyWeather={item} />
+        ))}
       </div>
     </div>
   );

--- a/src/types/userInfo.ts
+++ b/src/types/userInfo.ts
@@ -1,4 +1,11 @@
-export type UserInfo = {
+export type LoginInput = {
   email: string;
   password: string;
+};
+
+export type UserInfo = {
+  memberId: number;
+  email: string;
+  nickname: string;
+  imageUrl: string;
 };

--- a/src/types/weather.ts
+++ b/src/types/weather.ts
@@ -1,0 +1,12 @@
+export type WeatherInfo = {
+  temp: number;
+  icon: string;
+  todayMax: number;
+  todayMin: number;
+};
+
+export type HourlyWeather = {
+  time: string;
+  temp: number;
+  icon: string;
+};


### PR DESCRIPTION
## 📝 작업 내용
- **날씨 api 연결**
- **사용자 포인트 api 연결** 
- **사용자 프로필 이미지 api 연결**
  - 로그인 성공 시 응답으로 받은 프로필 이미지 URL을 로컬스토리지에 저장하고, 메인 화면에서 이를 불러와 표시하도록 구현했습니다.
  - 현재는 빠른 구현을 위해 로컬스토리지를 활용했으나, 추후 상태 관리에 대해 논의해 봐야 할 거 같습니다.
- **UX 개선**
  - 기존에는 미션 및 마이페이지 이동 시 화살표 아이콘만 클릭 가능했으나, 텍스트 영역까지 클릭 가능하도록 범위를 확장하여 접근성을 개선했습니다. 
<br>

## 📸 스크린샷
|메인페이지|
|---|
|<img width="529" height="1167" alt="image" src="https://github.com/user-attachments/assets/31c5c8cd-3e37-4650-9105-0c01b4aab689" />|
<br>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 메인 화면에 실시간 날씨(현재·시간대별), 오늘 최고/최저 기온, 내 포인트 및 계산된 날짜 표시
  - 로그인 성공 시 프로필 이미지 즉시 반영 및 자동 로드

- Improvements
  - 로그인 입력 검증 강화 및 실패 시 입력 폼만 초기화
  - 로그인 성공 후 토큰 저장 및 홈으로 즉시 이동, 콘솔 로그 제거

- Style
  - 네비게이션 항목 클릭 영역을 단일 버튼으로 통합 및 간격/정렬 개선
  - 날씨 아이콘·시간별 카드 크기 및 간격 조정으로 가독성 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->